### PR TITLE
Add jq as dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ This utility/helper script is made available to assist in  the attachment and de
 
 **Ubuntu/Debian**:
 
-    apt-get install open-iscsi multipath-tools
+    apt-get install open-iscsi multipath-tools jq
 
 
 **CentOS**:
 
-    yum -y install iscsi-initiator-utils device-mapper-multipath
+    yum -y install iscsi-initiator-utils device-mapper-multipath jq
 
 ## Installation
 


### PR DESCRIPTION
Make sure jq is installed before the script runs. See #7 for motivation.
