### PR TITLE
reload multipath configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This utility/helper script is made available to assist in  the attachment and de
 **Using git:**
 
     sudo su -
-    git clone git@github.com:promaethius/packet-block-storage.git
+    git clone git@github.com:packethost/packet-block-storage.git
     cp ./packet-block-storage/packet-block-storage-* /usr/bin/
     chmod u+x /usr/bin/packet-block-storage-*
 
@@ -35,8 +35,8 @@ This utility/helper script is made available to assist in  the attachment and de
 **Using wget**
 
     sudo su -
-    wget -O /usr/bin/packet-block-storage-attach https://raw.githubusercontent.com/promaethius/packet-block-storage/master/packet-block-storage-attach
-    wget -O /usr/bin/packet-block-storage-detach https://raw.githubusercontent.com/promaethius/packet-block-storage/master/packet-block-storage-detach
+    wget -O /usr/bin/packet-block-storage-attach https://raw.githubusercontent.com/packethost/packet-block-storage/master/packet-block-storage-attach
+    wget -O /usr/bin/packet-block-storage-detach https://raw.githubusercontent.com/packethost/packet-block-storage/master/packet-block-storage-detach
     chmod u+x /usr/bin/packet-block-storage-*
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This utility/helper script is made available to assist in  the attachment and de
 **Using git:**
 
     sudo su -
-    git clone git@github.com:packethost/packet-block-storage.git
+    git clone git@github.com:promaethius/packet-block-storage.git
     cp ./packet-block-storage/packet-block-storage-* /usr/bin/
     chmod u+x /usr/bin/packet-block-storage-*
 
@@ -35,8 +35,8 @@ This utility/helper script is made available to assist in  the attachment and de
 **Using wget**
 
     sudo su -
-    wget -O /usr/bin/packet-block-storage-attach https://raw.githubusercontent.com/packethost/packet-block-storage/master/packet-block-storage-attach
-    wget -O /usr/bin/packet-block-storage-detach https://raw.githubusercontent.com/packethost/packet-block-storage/master/packet-block-storage-detach
+    wget -O /usr/bin/packet-block-storage-attach https://raw.githubusercontent.com/promaethius/packet-block-storage/master/packet-block-storage-attach
+    wget -O /usr/bin/packet-block-storage-detach https://raw.githubusercontent.com/promaethius/packet-block-storage/master/packet-block-storage-detach
     chmod u+x /usr/bin/packet-block-storage-*
 
 ## Usage

--- a/packet-block-storage-attach
+++ b/packet-block-storage-attach
@@ -168,10 +168,6 @@ cat <<- EOF_mpconf > /etc/multipath.conf
 	}
 	EOF_mpconf
 	
-# Reload multipath's configuration to use user_friendly_names from the bindings file for CoreOS
-if [ $(head -1 /etc/lsb-release) == "DISTRIB_ID=CoreOS" ]; then
-	multipathd reconfigure
-fi
 
 # Initiator check
 if [ ! `grep $initiator\$ /etc/iscsi/initiatorname.iscsi` ]; then
@@ -274,6 +270,11 @@ fi
 
 mpresult=`multipath -ll`
 [ $_V -eq 1 ] && echo "$mpresult"
+
+# Reload multipath's configuration to use user_friendly_names from the bindings file for CoreOS
+if [ $(head -1 /etc/lsb-release) == "DISTRIB_ID=CoreOS" ]; then
+	multipathd reconfigure
+fi
 
 # Check for block device(s)
 for (( volume=0; volume<$volumecnt; volume++ )); do

--- a/packet-block-storage-attach
+++ b/packet-block-storage-attach
@@ -270,6 +270,9 @@ fi
 mpresult=`multipath -ll`
 [ $_V -eq 1 ] && echo "$mpresult"
 
+# Reload multipath's configuration to use user_friendly_names from the bindings file
+multipathd reconfigure
+
 # Check for block device(s)
 for (( volume=0; volume<$volumecnt; volume++ )); do
 	volname=`jq '.volumes['$volume'].name ' $LOCALMD | sed 's/"//g'`

--- a/packet-block-storage-attach
+++ b/packet-block-storage-attach
@@ -120,7 +120,7 @@ function restart_iscsid {
 
 # create the multipath config
 cat <<- EOF_mpconf > /etc/multipath.conf
-defaults {
+	defaults {
 
        polling_interval       3
        fast_io_fail_tmo 5
@@ -131,9 +131,9 @@ defaults {
        no_path_retry              $mpnpropt
        user_friendly_names     yes
 
-}
+	}
 
-blacklist {
+	blacklist {
          devnode "^(ram|raw|loop|fd|md|dm-|sr|scd|st)[0-9]*"
          devnode "^hd[a-z][[0-9]*]"
          devnode "^vd[a-z]"
@@ -153,9 +153,9 @@ blacklist {
                vendor  "DELL"
                product ".*"
          }
-}
+	}
 
-devices {
+	devices {
         device {
                 vendor "DATERA"
                 product "IBLOCK"
@@ -165,8 +165,13 @@ devices {
                 #prio_callout "/sbin/mpath_prio_alua /dev/%n"
                 hardware_handler "1 alua"
         }
-}
-EOF_mpconf
+	}
+	EOF_mpconf
+	
+# Reload multipath's configuration to use user_friendly_names from the bindings file for CoreOS
+if [ $(head -1 /etc/lsb-release) == "DISTRIB_ID=CoreOS" ]; then
+	multipathd reconfigure
+fi
 
 # Initiator check
 if [ ! `grep $initiator\$ /etc/iscsi/initiatorname.iscsi` ]; then
@@ -269,9 +274,6 @@ fi
 
 mpresult=`multipath -ll`
 [ $_V -eq 1 ] && echo "$mpresult"
-
-# Reload multipath's configuration to use user_friendly_names from the bindings file
-multipathd reconfigure
 
 # Check for block device(s)
 for (( volume=0; volume<$volumecnt; volume++ )); do


### PR DESCRIPTION
This solves https://github.com/packethost/packet-block-storage/issues/9 by reloading the multipath configuration file. Allows the use of this script for CoreOS.