### PR TITLE
attach: verify the jq download against a sha256sum

### DIFF
--- a/packet-block-storage-attach
+++ b/packet-block-storage-attach
@@ -37,7 +37,28 @@ fi
 # Depends on jq
 if [ ! `which jq` ]; then
 	echo "JQ was not found. Installing..."
-	wget --quiet -O /bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 && chmod +x /bin/jq
+
+        if ! apt install -qy jq; then
+                jqtmp="$(mktemp)"
+                if [[ ! -f "$jqtmp" ]]; then
+                        echo "mktemp failed, bailing..." >&2
+                        exit 1
+                fi
+                jqurl="https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64"
+                jqsha="c6b3a7d7d3e7b70c6f51b706a3b90bd01833846c54d32ca32f0027f00226ff6d  $jqtmp"
+                if ! curl -sLo "$jqtmp" "$jqurl"; then
+                        echo "Download of jq failed. Cannot continue. Install jq by handle to continue" >&2
+                        exit 1
+                fi
+                if echo "$jqsha" | sha256sum -c; then
+                        chmod +x "$jqtmp"
+                        mv "$jqtmp" /bin/jq || exit 1
+                else
+                        rm "$jqtmp"
+                        echo "Download of jq was invalid. Cannot continue. Install jq by hand to continue" >&2
+                        exit 1
+                fi
+        fi
 fi
 
 # Check for deps


### PR DESCRIPTION
You have other outstanding patches relating to the jq installation that might be considered, but at minimum something like this should be done to remove a potential root privilege being given to an arbitrary individual / group of individuals.

---

The downloaded binary was being trusted as-is, which means stedolan may be
capable of adding binaries that run with root privaleges to arbitrary newly
provision packet hosts without anyone really being any the wiser.

This patch assumes that 8 space indentation is ok, which is used in some
places in the file, tabs are elsewhere.

This patch is submitted under the assumption of either an MIT or a BSD
license and should be treated as such. The repository needs to be marked with
a license and a CLA.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/packethost/packet-block-storage/15)
<!-- Reviewable:end -->
