### PR TITLE
Add deferred_remove option to multipath config

### DIFF
--- a/packet-block-storage-attach
+++ b/packet-block-storage-attach
@@ -209,6 +209,7 @@ defaults {
        failback                    immediate
        no_path_retry              $mpnpropt
        user_friendly_names     yes
+       deferred_remove         yes
 
 }
 


### PR DESCRIPTION
Fixes #24

**Before:**
```
Feb 21 06:32:34 machine multipathd[12098]: sdb: remove path (uevent)
Feb 21 06:32:34 machine multipathd[12098]: volume-652b2041: load table [0 20971520 multipath 1 retain_attached_hw_handler 1 alua 1 1 round-robin 0 1 1 8:32 50]
Feb 21 06:32:34 machine multipathd[12098]: sdb [8:16]: path removed from map volume-652b2041
Feb 21 06:32:34 machine multipathd[12098]: sdc: remove path (uevent)
Feb 21 06:32:34 machine multipathd[12098]: volume-652b2041: map in use
Feb 21 06:32:34 machine multipathd[12098]: volume-652b2041: can't flush
Feb 21 06:32:34 machine multipathd[12098]: volume-652b2041: load table [0 20971520 multipath 1 retain_attached_hw_handler 1 alua 0 0]
Feb 21 06:32:34 machine multipathd[12098]: sdc [8:32]: path removed from map volume-652b2041
```
**After:**
```
Feb 21 06:49:38 machine multipathd[12624]: sdb: remove path (uevent)
Feb 21 06:49:38 machine multipathd[12624]: volume-652b2041: load table [0 20971520 multipath 1 retain_attached_hw_handler 1 alua 1 1 round-robin 0 1 1 8:32 50]
Feb 21 06:49:38 machine multipathd[12624]: sdb [8:16]: path removed from map volume-652b2041
Feb 21 06:49:38 machine multipathd[12624]: sdc: remove path (uevent)
Feb 21 06:49:38 machine multipathd[12624]: volume-652b2041: devmap deferred remove
Feb 21 06:49:38 machine multipathd[12624]: volume-652b2041: load table [0 20971520 multipath 1 retain_attached_hw_handler 1 alua 0 0]
Feb 21 06:49:38 machine multipathd[12624]: sdc [8:32]: path removed from map volume-652b2041
Feb 21 06:49:38 machine multipathd[12624]: dm-0: mapname not found for 254:0
Feb 21 06:49:38 machine multipathd[12624]: uevent trigger error
Feb 21 06:49:38 machine multipathd[12624]: dm-0: remove map (uevent)
Feb 21 06:49:43 machine multipathd[12624]: volume-652b2041: remove dead map
Feb 21 06:49:43 machine multipathd[12624]: volume-652b2041: stop event checker thread (140602333275904)
```