### PR TITLE
Make posix compliant, and add config-only option

### DIFF
--- a/packet-block-storage-attach
+++ b/packet-block-storage-attach
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Packet.net block storage auto-attach - dlaube
 
 set -e
@@ -6,29 +6,47 @@ set -e
 [ -n "$DEBUG" ] && set -x
 
 usage(){
-  echo "usage: $0 [-vhmn] [volume_name]"
+  echo "usage: $0 [-vhmnc] [volume_name]"
   echo "	-v		Make verbose"
   echo "	-h		Display help"
   echo "	-n		Do not try to attach any volumes; just ensure that iscsid and multipath are set up correctly"
+  echo "	-c		Do not start or restart multipathd or iscsid; just set up the correct configuration and ensure dependencies are installed"
   echo "	-m		Set multipath feature no_path_retry, ex: -m [<fail (default) | queue>]"
   echo "			If block storage is unreachable, the option "fail" results in FS read-only and "queue" will keep IO in memory buffer until reachable"
   echo "	volume_name	Specify the volume name to attach, eg: volume-f9a8a263"
   exit 1
 }
 
+hasSystemctl=0
+set +e
+systemctl 2>/dev/null | grep -q '^\s*\-\.mount'
+[ $? -eq 0 ] && hasSystemctl=1
+set -e
+
+
+restart_all() {
+	local configonly="$1"
+	if [ $configonly -ne 1 ]; then
+		[ $_V -eq 1 ] && echo "restarting iscsid and resetting multipath"
+		restart_iscsid
+		sleep 2
+		multipath
+	fi
+}
+
 restart_iscsid() {
-        if [[ `which systemctl` && `systemctl` =~ -\.mount ]]; then
+        if [ "$hasSystemctl" -eq 1 ]; then
                 [ $_V -eq 1 ] && echo "Restarting iscsid with systemctl"
                 systemctl restart iscsid &>/dev/null
                 if systemctl -q is-active open-iscsi; then
                         systemctl restart open-iscsi &>/dev/null
                 fi
 	# for alpine
-        elif [[ -f /etc/init.d/iscsid && ! -h /etc/init.d/iscsid ]]; then
+        elif [ -f /etc/init.d/iscsid -a ! -h /etc/init.d/iscsid ]; then
                 [ $_V -eq 1 ] && echo "Restarting iscsid with sysv init"
                 /etc/init.d/iscsid restart &>/dev/null
 	fi
-        if [[ -f /etc/init.d/open-iscsi && ! -h /etc/init.d/open-iscsi ]]; then
+        if [ -f /etc/init.d/open-iscsi -a ! -h /etc/init.d/open-iscsi ]; then
                 [ $_V -eq 1 ] && echo "Restarting iscsid with sysv init"
                 /etc/init.d/open-iscsi restart &>/dev/null
         fi
@@ -41,9 +59,10 @@ attach_volumes() {
 	if [ "$targetidx" ] ; then
 		attach_volume "$targetidx" "$metadatapath"
 	else
-		for (( idx=0; idx<$volumecnt; idx++ ))
-		do
+		idx=0
+		while [ $idx -lt $volumecnt ]; do
 			attach_volume "$idx" "$metadatapath"
+			idx=$(( $idx + 1 ))
 		done
 	fi
 }
@@ -62,7 +81,7 @@ attach_volume() {
 	portals=`jq -r '.volumes['$volume'].ips[] ' $metadatapath `
 	volname=`jq -r '.volumes['$volume'].name ' $metadatapath `
 
-	for portal in ${portals[@]}; do
+	for portal in ${portals}; do
 		echo "portal: $portal iqn: $iqn"
 		# Discover
 		if iscsiadm --mode discovery --type sendtargets --portal $portal --discover &>/dev/null ; then
@@ -172,27 +191,28 @@ enable_multipath() {
 	else
         	[ $_V -eq 1 ] && echo "Multipath module not yet loaded. Restarting service."
         	# Run multipath
-        	if [[ -f /usr/bin/systemctl && `systemctl` =~ -\.mount ]]; then
+        	if [ "$hasSystemctl" -eq 1 ]; then
                 	[ $_V -eq 1 ] && echo "Restarting multipath with systemctl"
 			modprobe dm_multipath
 			modprobe dm_round_robin
                 	systemctl restart multipathd
                 	systemctl enable multipathd
-        	elif [[ -f /etc/init.d/multipath-tools && ! -h /etc/init.d/multipath-tools ]]; then
+        	elif [ -f /etc/init.d/multipath-tools -a ! -h /etc/init.d/multipath-tools ]; then
                 	[ $_V -eq 1 ] && echo "Restarting multipath with sysv init"
                 	/etc/init.d/multipath-tools restart &>/dev/null
 		# for alpine linux
-        	elif [[ -f /etc/init.d/multipathd && ! -h /etc/init.d/multipathtd ]]; then
+        	elif [ -f /etc/init.d/multipathd -a ! -h /etc/init.d/multipathtd ]; then
                 	[ $_V -eq 1 ] && echo "Restarting multipath with sysv init"
                 	/etc/init.d/multipathd restart &>/dev/null
         	fi
 
         	# Restart multipath with sysv init to fix ubuntu/deb
-        	if [[ -f /etc/init.d/multipath-tools && ! -h /etc/init.d/multipath-tools ]]; then
+        	if [ -f /etc/init.d/multipath-tools -a ! -h /etc/init.d/multipath-tools ]; then
                 	[ $_V -eq 1 ] && echo "Restarting multipath with sysv init"
                 	/etc/init.d/multipath-tools restart &>/dev/null
         	fi
 	fi
+	true
 }
 
 create_multipath_config() {
@@ -265,11 +285,6 @@ validate_iscsi_config() {
 		sed -i.bak 's/node.session.timeo.replacement_timeout = 15/node.session.timeo.replacement_timeout = 5/g' $iscsiconf
 		sed -i.bak 's/node.conn\[0\].timeo.noop_out_interval = 5/node.conn\[0\].timeo.noop_out_interval = 3/g' $iscsiconf
 		sed -i.bak 's/node.conn\[0\].timeo.noop_out_timeout = 5/node.conn\[0\].timeo.noop_out_timeout = 3/g' $iscsiconf
-		# Restart iscsid since it will have old config values stored
-		echo "restarting iscsid"
-		restart_iscsid
-		sleep 2
-		multipath
 	fi
 }
 
@@ -279,10 +294,6 @@ update_initiator() {
 	if [ ! `grep $initiator\$ /etc/iscsi/initiatorname.iscsi` ]; then
 		[ $_V -eq 1 ] && echo "Initiator name mismatch! Updating from metadata..."
 		echo "InitiatorName=$initiator" > /etc/iscsi/initiatorname.iscsi
-		# Restart iscsid since it will have cached the previous initiator IQN
-		[ $_V -eq 1 ] && echo "restarting iscsid"
-		restart_iscsid
-		multipath
 	fi
 }
 
@@ -298,12 +309,15 @@ get_target_idx() {
   	fi
 
 	if [ "$target" ] ; then
-		for (( idx=0; idx<$volumecnt; idx++ )) ; do
+		idx=0
+		while [ $idx -lt $volumecnt ]; do
 			volname=`jq -r '.volumes['$idx'].name ' $metadatapath `
 			if [ "$volname" = "$target" ] ; then
 				targetidx=$idx
+				idx=$(( $idx + 1 ))
 				continue
 			fi
+			idx=$(( $idx + 1 ))
  	 	done
 
   		if [ ! "$targetidx" ] ; then
@@ -316,7 +330,9 @@ get_target_idx() {
 
 clean_mpath_bindings() {
 	# cleanup mpath entries in bindings file
-	sed -i "/^mpath.*/d" /etc/multipath/bindings
+	# remove old ones if the file already exists
+	[ -f /etc/multipath/bindings ] && sed -i "/^mpath.*/d" /etc/multipath/bindings
+	# add all of the existing known ones
 	if `ls /dev/mapper/mpath* >/dev/null 2>/dev/null`; then
 		[ $_V -eq 1 ] && echo "mpath volume entries found, cleaning up"
 		for i in `ls /dev/mapper/mpath* | cut -d / -f4`; do
@@ -331,7 +347,8 @@ report_status() {
 	local volumecnt="$1"
 	local metadatapath="$2"
 
-	for (( volume=0; volume<$volumecnt; volume++ )); do
+	volume=0
+	while [ $volume -lt $volumecnt ]; do
        		volname=`jq -r '.volumes['$volume'].name ' $metadatapath`
         	thiswwid=$(grep $volname /etc/multipath/bindings | awk {'print $2'})
 	        if [ -b /dev/mapper/$volname ]; then
@@ -345,6 +362,7 @@ report_status() {
         	else
                 	echo "Error: Block device /dev/mapper/$volname is NOT available for use"
         	fi
+		volume=$(($volume + 1))
 	done
 }
 
@@ -352,14 +370,16 @@ report_status() {
 _V=0
 mpnpropt="fail" # multipath no_path_retry default
 noattach=0
+configonly=0
 
-while getopts "m:vhn" OPTION
+while getopts "m:vhnc" OPTION
 do
     case $OPTION in
         v) _V=1;;
         h) usage;;
 	m) mpnpropt="$OPTARG";;
         n) noattach=1;;
+        c) configonly=1;;
         *) exit 1;;
     esac
 done
@@ -372,7 +392,7 @@ fi
 [ $_V -eq 1 ] && echo "Multipath no_path_retry feature option set as '$mpnpropt'"
 
 ensure_deps
-enable_multipath
+[ $configonly -ne 1 ] && enable_multipath
 
 export LOCALMD=/tmp/metadata.tmp
 curl -sSL https://metadata.packet.net/metadata > $LOCALMD
@@ -388,7 +408,9 @@ fi
 
 create_multipath_config "$mpnpropt"
 update_initiator "$initiator"
+restart_all "$configonly"
 validate_iscsi_config
+restart_all "$configonly"
 
 # attach volumes - but only if noattach was not set
 [ $noattach -ne 1 ] && attach_volumes "$volumecnt" "$targetidx" "$LOCALMD"


### PR DESCRIPTION
As described. 

* Making it pure posix sh compliant will make it easier to run on systems without `bash` (e.g. Alpine Linux, where bash needs to be added explicitly and has overhead). 
* The config-only option makes it possibly to set everything up without running the actual daemons, e.g. if you want to start them in a separate step
* Check for existence of `/etc/multipath/bindings` before trying to modify it

Testing now on the standard systems.